### PR TITLE
add batch_query_array which flattens nested vec to two numpy arrays before returning to python

### DIFF
--- a/cpp/main.cc
+++ b/cpp/main.cc
@@ -33,6 +33,9 @@ PYBIND11_MODULE(PRTree, m)
       .def("batch_query", &PRTree<T, B, 2>::find_all, R"pbdoc(
           parallel query with multi-thread
         )pbdoc")
+      .def("batch_query_array", &PRTree<T, B, 2>::find_all_array, R"pbdoc(
+          parallel query with multi-thread with array output
+        )pbdoc")
       .def("erase", &PRTree<T, B, 2>::erase, R"pbdoc(
           Delete from prtree
         )pbdoc")
@@ -74,6 +77,9 @@ PYBIND11_MODULE(PRTree, m)
       .def("batch_query", &PRTree<T, B, 3>::find_all, R"pbdoc(
           parallel query with multi-thread
         )pbdoc")
+      .def("batch_query_array", &PRTree<T, B, 3>::find_all_array, R"pbdoc(
+          parallel query with multi-thread with array output
+        )pbdoc")
       .def("erase", &PRTree<T, B, 3>::erase, R"pbdoc(
           Delete from prtree
         )pbdoc")
@@ -114,6 +120,9 @@ PYBIND11_MODULE(PRTree, m)
         )pbdoc")
       .def("batch_query", &PRTree<T, B, 4>::find_all, R"pbdoc(
           parallel query with multi-thread
+        )pbdoc")
+      .def("batch_query_array", &PRTree<T, B, 4>::find_all_array, R"pbdoc(
+          parallel query with multi-thread with array output
         )pbdoc")
       .def("erase", &PRTree<T, B, 4>::erase, R"pbdoc(
           Delete from prtree

--- a/cpp/prtree.h
+++ b/cpp/prtree.h
@@ -51,6 +51,38 @@ namespace py = pybind11;
 template <class T>
 using vec = std::vector<T>;
 
+template <typename Sequence >
+inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence& seq) {
+
+  auto size = seq.size();
+  auto data = seq.data();
+  std::unique_ptr<Sequence> seq_ptr = std::make_unique<Sequence>(std::move(seq));
+  auto capsule = py::capsule(seq_ptr.get(), [](void *p) { std::unique_ptr<Sequence>(reinterpret_cast<Sequence*>(p)); });
+  seq_ptr.release();
+  return py::array(size, data, capsule);
+}
+
+template <typename T>
+auto list_list_to_arrays(vec<vec<T>> out_ll){
+  vec<T> out_s;
+  out_s.reserve(out_ll.size());
+  std::size_t sum = 0;
+  for (auto &&i : out_ll) {
+    out_s.push_back(i.size());
+    sum += i.size();
+  }
+  vec<T> out;
+  out.reserve(sum);
+  for(const auto &v: out_ll)
+    out.insert(out.end(), v.begin(), v.end());
+
+  return make_tuple(
+      std::move(as_pyarray(out_s))
+      ,
+      std::move(as_pyarray(out))
+  );
+}
+
 template <class T, size_t StaticCapacity>
 using svec = itlib::small_vector<T, StaticCapacity>;
 
@@ -722,6 +754,8 @@ public:
     archive(flat_tree, idx2bb, idx2data, global_idx, n_at_build);
   }
 
+
+
   void save(std::string fname)
   {
     {
@@ -1257,6 +1291,10 @@ public:
     std::cout << "profiler end of find_all" << std::endl;
 #endif
     return out;
+  }
+
+  auto find_all_array(const py::array_t<float> &x){
+    return list_list_to_arrays(std::move(find_all(x)));
   }
 
   auto find_one(const vec<float> &x)

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,14 @@ class CMakeBuild(build_ext):
             ["cmake", "--build", "."] + build_args, cwd=self.build_temp
         )
 
+        if platform.system()=='Darwin':
+            from pathlib import Path
+            for p in Path(extdir).glob('*.so'):
+                subprocess.check_call(
+                    ["codesign","-s", "-", "-f", str(p)],
+                    cwd=self.build_temp,
+                )
+
 
 setup(
     name="python_prtree",


### PR DESCRIPTION
Hi, I am trying to update trimesh so it uses python_prtree for its bounding boxes queries, and a crucial adjustment for performance is having the output of `batch_query` as numpy arrays.

This PR  adds a new method to `PRTree*`, `batch_query_array`, that flattens the list[list[int]] output of `batch_query` into two arrays: the count of candidates for each bound, and the candidates for each bound listed sequentially.

I split the implementation into a flattening function `list_list_to_arrays` and `batch_query_array` which calls `batch_query` and passes the `vec<vec<T>>` to `list_list_to_arrays`.

The conversion from `vec<T>` to `pyarray` is done via `as_pyarray` which I took from here https://github.com/pybind/pybind11/issues/1042#issuecomment-642215028 .

I'm very green when it comes to using pybind11, so I might have made a mistake with memory management, but all tests passed, and my own use-case seems to work fine. I'm sure this will be further useful for anyone wanting to use the output of `batch_query` with decent performance.

Closes https://github.com/atksh/python_prtree/issues/34